### PR TITLE
Add package footer for packaging convention

### DIFF
--- a/github-issues.el
+++ b/github-issues.el
@@ -251,3 +251,4 @@
   (toggle-read-only t))
 
 (provide 'github-issues)
+;;; github-issues.el ends here


### PR DESCRIPTION
Github diff viewer is strange. I added following line at end of file.

https://github.com/syohex/github-issues.el/blob/21d73b6e2c361c8732b1dbe735ad02951feba190/github-issues.el#L255
