### PR TITLE
Declare buffer local variables as global variable

### DIFF
--- a/github-issues.el
+++ b/github-issues.el
@@ -46,6 +46,10 @@
 (require 'url)
 (require 'font-lock)
 
+(defvar github-current-user)
+(defvar github-current-repo)
+(defvar github-current-issue)
+
 (defun github-parse-response (buffer)
   "Parses the JSON response from a GitHub API call."
   (let ((json-object-type 'plist))


### PR DESCRIPTION
This fixes many byte-compile warnings.

```
github-issues.el:87:17:Warning: reference to free variable
    `github-current-user'
github-issues.el:88:17:Warning: reference to free variable
    `github-current-repo'
github-issues.el:89:38:Warning: assignment to free variable
    `github-current-user'       
github-issues.el:89:38:Warning: assignment to free variable
    `github-current-repo'          
github-issues.el:89:17:Warning: assignment to free variable
    `github-current-issue'
```
